### PR TITLE
fix error path to cfg

### DIFF
--- a/hy3dpaint/textureGenPipeline.py
+++ b/hy3dpaint/textureGenPipeline.py
@@ -39,7 +39,6 @@ class Hunyuan3DPaintConfig:
         self.device = "cuda"
 
         self.multiview_cfg_path = "hy3dpaint/cfgs/hunyuan-paint-pbr.yaml"
-        self.multiview_cfg_path = "cfgs/hunyuan-paint-pbr.yaml"
 
         self.multiview_pretrained_path = "tencent/Hunyuan3D-2.1"
         self.dino_ckpt_path = "facebook/dinov2-giant"


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/ubuntu/Hunyuan3D_2.1/demo.py", line 37, in <module>
    paint_pipeline = Hunyuan3DPaintPipeline(conf)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/Hunyuan3D_2.1/hy3dpaint/textureGenPipeline.py", line 86, in __init__
    self.load_models()
  File "/home/ubuntu/Hunyuan3D_2.1/hy3dpaint/textureGenPipeline.py", line 91, in load_models
    self.models["multiview_model"] = multiviewDiffusionNet(self.config)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/Hunyuan3D_2.1/hy3dpaint/utils/multiview_utils.py", line 32, in __init__
    cfg = OmegaConf.load(cfg_path)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/anaconda3/envs/comfy/lib/python3.12/site-packages/omegaconf/omegaconf.py", line 189, in load
    with io.open(os.path.abspath(file_), "r", encoding="utf-8") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/Hunyuan3D_2.1/cfgs/hunyuan-paint-pbr.yaml' (comfy) ubuntu@ip-172-31-41-22:~/Hunyuan3D_2.1$
```

after fix it works