### PR TITLE
fix default save dir folder

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -741,7 +741,7 @@ if __name__ == '__main__':
     parser.add_argument('--host', type=str, default='0.0.0.0')
     parser.add_argument('--device', type=str, default='cuda')
     parser.add_argument('--mc_algo', type=str, default='mc')
-    parser.add_argument('--cache-path', type=str, default='/root/save_dir')
+    parser.add_argument('--cache-path', type=str, default=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'output'))
     parser.add_argument('--enable_t23d', action='store_true')
     parser.add_argument('--disable_tex', action='store_true')
     parser.add_argument('--enable_flashvdm', action='store_true')


### PR DESCRIPTION
Creates an 'output' folder in the same directory as the Gradio app script, compatible with both Linux and Windows.
fix for https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1/issues/23