### PR TITLE
【犀牛鸟实战issue】overfitting fail

### DIFF
--- a/dit_asl.yaml
+++ b/dit_asl.yaml
@@ -1,30 +1,34 @@
 name: "HunyuanDiT-overfit-mini"
 
 training:
-  steps: 800               # mini数据集上更好的选择800步即可满足需求
-  base_lr: 5e-5            # 提高模型的相关过拟合性，稍降学习率
   val_check_interval: 9999 # 不验证
   limit_val_batches: 0
+  steps: 200
+  base_lr: 1e-3          # 稍大学习率加速下降
+  weight_decay: 0        # 过拟合阶段关闭 L2
+  grad_clip: 1.0
+  save_every: 50
   every_n_train_steps: 200 # 每 200 步存一次 ckpt
-  monitor: null            # 关闭 monitor
+  monitor: null            
+  dtype: "float16"
 
 dataset:
   target: hy3dshape.data.dit_asl.AlignedShapeLatentModule
   params:
     batch_size: 1          # 单卡单样本
-    num_workers: 4
+    num_workers: 0
     train_data_list: tools/tiny_trainset/preprocessed  # 指向 1 个样本
     val_data_list: tools/tiny_trainset/preprocessed
     image_size: 518
     mean: [0.5,0.5,0.5]
     std:  [0.5,0.5,0.5]
-    pc_size: 8192          # 降采样，减少显存
+    pc_size: 4096          # 降采样，减少显存
     return_normal: true
     padding: true
     augmentation:          # 轻量增强
       rotation: 15
       scale: [0.9,1.1]
-
+    shuffle: true
 model:
   target: hy3dshape.models.diffusion.flow_matching_sit.Diffuser
   params:
@@ -34,10 +38,10 @@ model:
     denoiser_cfg:
       target: hy3dshape.models.denoisers.hunyuandit.HunYuanDiTPlain
       params:
-        input_size: 1024     # 4096→1024，显存减半
+        input_size: 512     # 4096→1024，显存减半
         in_channels: 64
-        hidden_size: 1024    # 2048→1024
-        depth: 8             # 16→8
+        hidden_size: 512    # 2048→1024
+        depth: 4             # 16→8
         context_dim: 1024
         num_heads: 8
         dropout: 0.1         # 新增

--- a/train_mini_overfit.py
+++ b/train_mini_overfit.py
@@ -52,3 +52,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
任务说明：在小数据集上过模型效果不佳，在小数据集上模型能很好地解决
方案：模型会快速记住所有数据，但继续训练会导致优化器震荡，损失不降反升，从而形成“过结果效果不佳”，减少步数，增加正则化，降低学习率和提高数据增强性能，采用一下方式来检验：
1.观察训练损失：应快速恢复到接近0。
2.观察验证损失（如果有）：应快速上升（过精致的标志）。
3.生成样本：检查模型是否能完美重建训练数据。
完成修改dit_asl.yaml和train_mini_overfit.py是相应的模型权重训练和代码，提高了在迷你数据集上的过精致性能，降低了相应的损失度