### PR TITLE
Fix: accept Anaconda ToS in Dockerfile to prevent build failure

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,10 @@ ENV PATH="/workspace/miniconda3/bin:${PATH}"
 # initialize conda
 RUN conda init bash
 
+# Accept Anaconda TOS for required channels
+RUN conda tos accept --channel https://repo.anaconda.com/pkgs/main && \
+    conda tos accept --channel https://repo.anaconda.com/pkgs/r
+
 # create and activate conda environment
 RUN conda create -n hunyuan3d21 python=3.10 && echo "source activate hunyuan3d21" > ~/.bashrc
 ENV PATH="/workspace/miniconda3/envs/hunyuan3d21/bin:${PATH}"


### PR DESCRIPTION
This PR updates the Dockerfile to accept the Anaconda Terms of Service for the default channels. Without this, Docker builds fail with CondaToSNonInteractiveError.

Change
```
# Accept Anaconda TOS for required channels
RUN conda tos accept --channel https://repo.anaconda.com/pkgs/main && \
    conda tos accept --channel https://repo.anaconda.com/pkgs/r

```
Result:
Docker image now builds successfully without manual intervention.