### PR TITLE
避免打印非 ASCII 字符

### DIFF
--- a/hy3dpaint/convert_utils.py
+++ b/hy3dpaint/convert_utils.py
@@ -135,6 +135,6 @@ def create_glb_with_pbr_materials(obj_path, textures_dict, output_path):
 
     # 9. 保存最终GLB
     gltf.save(output_path)
-    print(f"PBR GLB文件已保存: {output_path}")
+    print(f"PBR GLB file saved: {output_path}")
 
 


### PR DESCRIPTION
在部分系统（Windows 10 且无中文支持）会报错

```
File "K:\Hunyuan3D2_WinPortable_cu129.7z\Hunyuan3D2_WinPortable\Hunyuan3D-2.1\hy3dpaint\convert_utils.py", line 138, in create_glb_with_pbr_materials
print(f"PBR GLB\u6587\u4ef6\u5df2\u4fdd\u5b58: {output_path}")
File "K:\Hunyuan3D2_WinPortable_cu129.7z\Hunyuan3D2_WinPortable\python_standalone\Lib\encodings\cp1252.py", line 19, in encode
return codecs.charmap_encode(input,self.errors,encoding_table)[0]
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode characters in position 7-11: character maps to <undefined>
./save_dir\980a2899-3718-4d88-943a-d2cb354f2522\white_mesh.glb
```

意料之外又在情理之中。简单替换文本为英文即可修复。