### PR TITLE
[fix-bug]删除bpy依赖，并修改纹理生成种obj文件转换为gltf文件

### DIFF
--- a/hy3dpaint/textureGenPipeline.py
+++ b/hy3dpaint/textureGenPipeline.py
@@ -20,12 +20,12 @@ import numpy as np
 from PIL import Image
 from typing import List
 from DifferentiableRenderer.MeshRender import MeshRender
+from convert_utils import create_glb_with_pbr_materials
 from utils.simplify_mesh_utils import remesh_mesh
 from utils.multiview_utils import multiviewDiffusionNet
 from utils.pipeline_utils import ViewProcessor
 from utils.image_super_utils import imageSuperNet
 from utils.uvwrap_utils import mesh_uv_wrap
-from DifferentiableRenderer.mesh_utils import convert_obj_to_glb
 import warnings
 
 warnings.filterwarnings("ignore")
@@ -33,6 +33,13 @@ from diffusers.utils import logging as diffusers_logging
 
 diffusers_logging.set_verbosity(50)
 
+def quick_convert_with_obj2gltf(obj_path: str, glb_path: str):
+    textures = {
+        'albedo': obj_path.replace('.obj', '.jpg'),
+        'metallic': obj_path.replace('.obj', '_metallic.jpg'),
+        'roughness': obj_path.replace('.obj', '_roughness.jpg')
+        }
+    create_glb_with_pbr_materials(obj_path, textures, glb_path)
 
 class Hunyuan3DPaintConfig:
     def __init__(self, max_num_view, resolution):
@@ -186,7 +193,7 @@ class Hunyuan3DPaintPipeline:
         self.render.save_mesh(output_mesh_path, downsample=True)
 
         if save_glb:
-            convert_obj_to_glb(output_mesh_path, output_mesh_path.replace(".obj", ".glb"))
+            quick_convert_with_obj2gltf(output_mesh_path, output_mesh_path.replace(".obj", ".glb"))
             output_glb_path = output_mesh_path.replace(".obj", ".glb")
 
         return output_mesh_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ psutil==6.0.0
 cupy-cuda12x==13.4.1
 
 # Blender
-bpy==4.0
+# bpy==4.0
 
 # ONNX Runtime
 onnxruntime==1.16.3


### PR DESCRIPTION
## 问题描述
修复bpy依赖无法安装，导致hy3dpaint/demo.py无法运行的问题

## 修改内容
- 注释掉 `requirements.txt` 中的 `bpy==4.0` 依赖，避免安装问题
- 替换 `convert_obj_to_glb` 函数为 `quick_convert_with_obj2gltf`
- 从 `convert_utils` 导入 `create_glb_with_pbr_materials`
- 添加 `quick_convert_with_obj2gltf` 函数以提供更好的GLB转换功能

## 测试
- [ ] 验证纹理生成管道正常工作
- [ ] 确认GLB文件正确生成