### PR TITLE
fix: replace 10 bare excepts with except Exception across 6 files

### DIFF
--- a/hy3dpaint/DifferentiableRenderer/MeshRender.py
+++ b/hy3dpaint/DifferentiableRenderer/MeshRender.py
@@ -30,12 +30,12 @@ from .camera_utils import (
 
 try:
     from .mesh_utils import load_mesh, save_mesh
-except:
+except Exception:
     print("Bpy IO CAN NOT BE Imported!!!")
 
 try:
     from .mesh_inpaint_processor import meshVerticeInpaint  # , meshVerticeColor
-except:
+except Exception:
     print("InPaint Function CAN NOT BE Imported!!!")
 
 

--- a/hy3dpaint/train.py
+++ b/hy3dpaint/train.py
@@ -157,7 +157,7 @@ class CodeSnapshot(Callback):
     def on_fit_start(self, trainer, pl_module):
         try:
             self.save_code_snapshot()
-        except:
+        except Exception:
             rank_zero_warn(
                 "Code snapshot is not saved. Please make sure you have git installed and are in a git repository."
             )
@@ -204,7 +204,7 @@ if __name__ == "__main__":
     rank_zero_print(f"Running on GPUs {opt.gpus}")
     try:
         ngpu = int(opt.gpus)
-    except:
+    except Exception:
         ngpu = len(opt.gpus.strip(",").split(","))
     trainer_config["devices"] = ngpu
 

--- a/hy3dshape/hy3dshape/models/autoencoders/surface_extractors.py
+++ b/hy3dshape/hy3dshape/models/autoencoders/surface_extractors.py
@@ -147,7 +147,7 @@ class DMCSurfaceExtractor(SurfaceExtractor):
             try:
                 from diso import DiffDMC
                 self.dmc = DiffDMC(dtype=torch.float32).to(device)
-            except:
+            except Exception:
                 raise ImportError("Please install diso via `pip install diso`, or set mc_algo to 'mc'")
         sdf = -grid_logit / octree_resolution
         sdf = sdf.to(torch.float32).contiguous()

--- a/hy3dshape/hy3dshape/models/diffusion/transport/integrators.py
+++ b/hy3dshape/hy3dshape/models/diffusion/transport/integrators.py
@@ -81,7 +81,7 @@ class sde:
 
         try:
             sampler = sampler_dict[self.sampler_type]
-        except:
+        except Exception:
             raise NotImplementedError("Smapler type not implemented.")
     
         return sampler

--- a/hy3dshape/tools/render/render.py
+++ b/hy3dshape/tools/render/render.py
@@ -234,7 +234,7 @@ def switch_to_color_render(output_nodes):
                 try:
                     node = bc_node.inputs[1].links[0].from_socket.node
                     node.image.colorspace_settings.name = 'sRGB'
-                except:
+                except Exception:
                     pass
 
 # def ConvertNormalMap(input_exr, output_jpg):

--- a/hy3dshape/tools/watertight/watertight_and_sample.py
+++ b/hy3dshape/tools/watertight/watertight_and_sample.py
@@ -94,7 +94,7 @@ def sample_sdf(mesh, random_surface, sharp_surface):
             mesh.vertices, mesh.faces, 
             return_normals=False,
             sign_type=sign_type)
-    except:
+    except Exception:
         vol_sdf, I, C = igl.signed_distance(
             vol_points.astype(np.float32), 
             mesh.vertices, mesh.faces, 
@@ -105,7 +105,7 @@ def sample_sdf(mesh, random_surface, sharp_surface):
             mesh.vertices, mesh.faces, 
             return_normals=False,
             sign_type=sign_type)
-    except:
+    except Exception:
         random_near_sdf, I, C = igl.signed_distance(
             random_near_points.astype(np.float32), 
             mesh.vertices, mesh.faces, 
@@ -116,7 +116,7 @@ def sample_sdf(mesh, random_surface, sharp_surface):
             mesh.vertices, mesh.faces, 
             return_normals=False,
             sign_type=sign_type)
-    except:
+    except Exception:
         sharp_near_sdf, I, C = igl.signed_distance(
             sharp_near_points.astype(np.float32), 
             mesh.vertices, mesh.faces, 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in 6 files (10 sites). Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`, preventing clean shutdown.

**Files:** `MeshRender.py` (2), `train.py` (2), `surface_extractors.py`, `integrators.py`, `render.py`, `watertight_and_sample.py` (3)