### PR TITLE
fix: Update pip install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https
 pip install -r requirements.txt
 
 cd hy3dpaint/custom_rasterizer
-pip install -e .
+pip install --no-build-isolation -e .
 cd ../..
 cd hy3dpaint/DifferentiableRenderer
 bash compile_mesh_painter.sh


### PR DESCRIPTION
Changed pip install command to include --no-build-isolation.

In the original installation scheme, directly using `pip install -e .` would result in the creation of a new build environment, which would throw an error due to the absence of `torch` in the environment:

```
ModuleNotFoundError: No module named 'torch'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
```
  
According to the installation sequence provided in the README, the most suitable build and installation method for installing `torch` during the previous environment setup should be `pip install --no-build-isolation -e .`. The --no-build-isolation parameter instructs pip to directly use the Python environment and installed packages to execute the build script, thereby recognizing the `torch` already installed following the aforementioned installation sequence and resolving potential error issues that may arise during the installation process.

@HuiwenShi   I provide a relatively stable and error-resistant installation process, and hope it can be adopted.