### PR TITLE
Make Hunyuan3DDiTPipeline.to() return self

### DIFF
--- a/hy3dshape/hy3dshape/pipelines.py
+++ b/hy3dshape/hy3dshape/pipelines.py
@@ -303,6 +303,7 @@ class Hunyuan3DDiTPipeline:
             self.vae.to(device)
             self.model.to(device)
             self.conditioner.to(device)
+        return self
 
     @property
     def _execution_device(self):


### PR DESCRIPTION
## Summary
- `Hunyuan3DDiTPipeline.to()` mutates `self` in place but does not return it.
- The standard PyTorch idiom (`nn.Module.to()`, `diffusers.DiffusionPipeline.to()`, etc.) returns `self` so callers can chain or reassign.
- Without the return, this common pattern silently breaks:

```python
pipe = Hunyuan3DDiTFlowMatchingPipeline.from_pretrained(...)
pipe = pipe.to("cuda")          # <- pipe is now None
mesh = pipe(image=..., ...)     # TypeError: 'NoneType' object is not callable
```

The in-place form (`pipe.to("cuda")` without reassignment) works because the method does mutate `self`, but matching the documented torch idiom should not crash.

## Change
One line in `hy3dshape/hy3dshape/pipelines.py:295` — add `return self` at the end of `to()`.

## Why this is safe
- Existing in-place callers (`pipe.to("cuda")` discarded return value) are unaffected.
- Chained / reassignment callers (`pipe = pipe.to("cuda")`) now work as expected.
- Matches `torch.nn.Module.to()` and `diffusers.DiffusionPipeline.to()` conventions.

## Test plan
- [x] Inference on a fresh install still works after the change.
- [x] `pipe = Hunyuan3DDiTFlowMatchingPipeline.from_pretrained(...).to("cuda")` produces a callable pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)